### PR TITLE
Adds version number for networkx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-networkx
+networkx=1.11
 requests
 nose
 pyrsistent


### PR DESCRIPTION
This adds a version number for the networkx package in requirements.txt.
The API changed substantially at version 2.0 so we simply use the
preceding version.